### PR TITLE
Create Tech Stack docs

### DIFF
--- a/techstack.md
+++ b/techstack.md
@@ -1,0 +1,66 @@
+<!--
+--- Readme.md Snippet without images Start ---
+## Tech Stack
+spryker-community/sprykerb2c-Marketplace-payment-integration-novalnet is built on the following main stack:
+- [PHP](http://www.php.net/) – Languages
+- [TypeScript](http://www.typescriptlang.org) – Languages
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet without images End ---
+
+--- Readme.md Snippet with images Start ---
+## Tech Stack
+spryker-community/sprykerb2c-Marketplace-payment-integration-novalnet is built on the following main stack:
+- <img width='25' height='25' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'/> [PHP](http://www.php.net/) – Languages
+- <img width='25' height='25' src='https://img.stackshare.io/service/1612/bynNY5dJ.jpg' alt='TypeScript'/> [TypeScript](http://www.typescriptlang.org) – Languages
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet with images End ---
+-->
+<div align="center">
+
+# Tech Stack File
+![](https://img.stackshare.io/repo.svg "repo") [spryker-community/sprykerb2c-Marketplace-payment-integration-novalnet](https://github.com/spryker-community/sprykerb2c-Marketplace-payment-integration-novalnet)![](https://img.stackshare.io/public_badge.svg "public")
+<br/><br/>
+|3<br/>Tools used|11/09/23 <br/>Report generated|
+|------|------|
+</div>
+
+## <img src='https://img.stackshare.io/languages.svg'/> Languages (2)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg' alt='PHP'>
+  <br>
+  <sub><a href="http://www.php.net/">PHP</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+<td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1612/bynNY5dJ.jpg' alt='TypeScript'>
+  <br>
+  <sub><a href="http://www.typescriptlang.org">TypeScript</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## <img src='https://img.stackshare.io/devops.svg'/> DevOps (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1046/git.png' alt='Git'>
+  <br>
+  <sub><a href="http://git-scm.com/">Git</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+<br/>
+<div align='center'>
+
+Generated via [Stack File](https://github.com/apps/stack-file)

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,0 +1,38 @@
+repo_name: spryker-community/sprykerb2c-Marketplace-payment-integration-novalnet
+report_id: 2dc2026fd10f0624b19e0f50da4a3862
+repo_type: Public
+timestamp: '2023-11-09T17:23:27+00:00'
+requested_by: Novalnet-Technic
+provider: github
+branch: master
+detected_tools_count: 3
+tools:
+- name: PHP
+  description: A popular general-purpose scripting language that is especially suited
+    to web development
+  website_url: http://www.php.net/
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/991/hwUcGZ41_400x400.jpg
+  detection_source: Repo Metadata
+- name: TypeScript
+  description: A superset of JavaScript that compiles to clean JavaScript output
+  website_url: http://www.typescriptlang.org
+  license: Apache-2.0
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/1612/bynNY5dJ.jpg
+  detection_source: Repo Metadata
+- name: Git
+  description: Fast, scalable, distributed revision control system
+  website_url: http://git-scm.com/
+  open_source: true
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Version Control System
+  image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source: Repo Metadata


### PR DESCRIPTION
PR to add tech stack documentation to allow anyone to easily see what is being used in this repo without digging through config files. Two files are being added: techstack.yml and techstack.md. The techstack.yml file contains data on all the tools being used in this repo. The techstack.md file is derived from the YML file and displays the tech stack data in Markdown.